### PR TITLE
change protobuf type for buffer from int64 to bytes

### DIFF
--- a/msgpack-test.py
+++ b/msgpack-test.py
@@ -33,8 +33,8 @@ def main():
             packed = msgpack.packb(useful_dict, use_bin_type=True)
             msgpackWroteSize += len(packed)
             outfile.write(packed)
-    msgpackExecutionTime = time.time() - start;     
-    print("\nTest msgpack")
+    msgpackExecutionTime = time.time() - start;
+    print("\nTest protobuf")
     start = time.time()
     with open("random.protobuf", "wb") as outfile:
         for x in range(args.iterations):
@@ -42,7 +42,7 @@ def main():
             event_data = test_pb2.EventData()
             event_data.counter = x
             event_data.channel_name = "string data"
-            event_data.buffer.extend(bytearray(os.urandom(byteToGenerate)))
+            event_data.buffer.append(bytes(os.urandom(byteToGenerate)))
             to_write = event_data.SerializeToString();
             protobufWroteSize += len(to_write)
             outfile.write(to_write)

--- a/test.proto
+++ b/test.proto
@@ -5,5 +5,5 @@ package test;
 message EventData {
     int32 counter = 1;
     string channel_name = 2;
-    repeated int32 buffer = 3 [packed=true];
+    repeated bytes buffer = 3;
 }

--- a/test_pb2.py
+++ b/test_pb2.py
@@ -13,15 +13,14 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\ntest.proto\x12\x04test\"F\n\tEventData\x12\x0f\n\x07\x63ounter\x18\x01 \x01(\x05\x12\x14\n\x0c\x63hannel_name\x18\x02 \x01(\t\x12\x12\n\x06\x62uffer\x18\x03 \x03(\x05\x42\x02\x10\x01\x62\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\ntest.proto\x12\x04test\"B\n\tEventData\x12\x0f\n\x07\x63ounter\x18\x01 \x01(\x05\x12\x14\n\x0c\x63hannel_name\x18\x02 \x01(\t\x12\x0e\n\x06\x62uffer\x18\x03 \x03(\x0c\x62\x06proto3')
 
-_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, globals())
-_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'test_pb2', globals())
+_globals = globals()
+_builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
+_builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'test_pb2', _globals)
 if _descriptor._USE_C_DESCRIPTORS == False:
 
   DESCRIPTOR._options = None
-  _EVENTDATA.fields_by_name['buffer']._options = None
-  _EVENTDATA.fields_by_name['buffer']._serialized_options = b'\020\001'
-  _EVENTDATA._serialized_start=20
-  _EVENTDATA._serialized_end=90
+  _globals['_EVENTDATA']._serialized_start=20
+  _globals['_EVENTDATA']._serialized_end=86
 # @@protoc_insertion_point(module_scope)


### PR DESCRIPTION

change protobuf type to bytes and instead of extending the repeatable buffer with a bytearray, simply append a bytestring